### PR TITLE
Fix metadict unpacking warning

### DIFF
--- a/metadict/__about__.py
+++ b/metadict/__about__.py
@@ -1,7 +1,7 @@
 import time
 
 _this_year = time.strftime("%Y")
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 __author__ = 'Lars Hillebrand'
 __author_email__ = 'hokage555@web.de'
 __license__ = 'Apache-2.0'

--- a/metadict/metadict.py
+++ b/metadict/metadict.py
@@ -2,6 +2,7 @@ import contextlib
 import keyword
 import re
 import warnings
+from collections.abc import KeysView
 from typing import MutableMapping, Dict, Iterator, TypeVar, Iterable, Optional, Mapping, Any, Tuple
 
 
@@ -55,6 +56,11 @@ class MetaDict(MutableMapping[KT, VT], dict):
             raise TypeError(f"Keyword argument 'nested_assignment' must be an instance of type 'bool'")
 
         # init internal attributes and data store
+        # dict.__setattr__(self, '_data', {})
+        # dict.__setattr__(self, '_nested_assignment', nested_assignment)
+        # dict.__setattr__(self, '_parent', kwargs.pop('_parent', None))
+        # dict.__setattr__(self, '_key', kwargs.pop('_key', None))
+        # dict.__setattr__(self, '_memory_map', {})
         self.__dict__['_data']: Dict[KT, VT] = {}
         self.__dict__['_nested_assignment'] = nested_assignment
         self.__dict__['_parent'] = kwargs.pop('_parent', None)
@@ -265,3 +271,17 @@ class MetaDict(MutableMapping[KT, VT], dict):
             elif isinstance(x, (list, set, tuple)):
                 return MetaDict._contains_mapping(x, ignore)
         return False
+
+    # add the following inherited methods from collections.abc.Mapping directly to make pycharm happy
+    # (removing an annoying warning for dict unpacking)
+    def __contains__(self, key):
+        try:
+            self[key]
+        except KeyError:
+            return False
+        else:
+            return True
+
+    def keys(self):
+        """D.keys() -> a set-like object providing a view on D's keys"""
+        return KeysView(self)

--- a/metadict/metadict.py
+++ b/metadict/metadict.py
@@ -56,11 +56,6 @@ class MetaDict(MutableMapping[KT, VT], dict):
             raise TypeError(f"Keyword argument 'nested_assignment' must be an instance of type 'bool'")
 
         # init internal attributes and data store
-        # dict.__setattr__(self, '_data', {})
-        # dict.__setattr__(self, '_nested_assignment', nested_assignment)
-        # dict.__setattr__(self, '_parent', kwargs.pop('_parent', None))
-        # dict.__setattr__(self, '_key', kwargs.pop('_key', None))
-        # dict.__setattr__(self, '_memory_map', {})
         self.__dict__['_data']: Dict[KT, VT] = {}
         self.__dict__['_nested_assignment'] = nested_assignment
         self.__dict__['_parent'] = kwargs.pop('_parent', None)

--- a/tests/test_metadict.py
+++ b/tests/test_metadict.py
@@ -143,6 +143,11 @@ def test_update(config: Dict):
     assert cfg == config
 
 
+def test_contains(config: Dict):
+    cfg = MetaDict(config)
+    assert 'model' in cfg
+
+
 def test_copy(config: Dict):
     cfg = MetaDict(config)
     assert copy.copy(cfg) is not cfg


### PR DESCRIPTION
Add `keys()` and `__contains__()` method directly to `MetaDict` to remove the PyCharm warning for dict unpacking. 

This should not be necessary since `MetaDict` already inherits both `keys()` and `__contains__()` from `MutableMapping`.