### PR TITLE
Fix memory map reference bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,17 +109,15 @@ $ pip install metadict
    >> True
    
    model_dict = {'params': params}
-   cfg = MetaDict(model_1=model_dict, model_2=model_dict)
-   print(cfg.model_1 is cfg.model_2)
-   >> True
-   print(cfg.model_1.params is params)
+   cfg = MetaDict(model=model_dict)
+   print(cfg.model.params is params)
    >> True
    
    # Note: dicts are recursively converted to MetaDicts, thus...
-   print(cfg.model_1 is model_dict)
+   print(cfg.model is model_dict)
    >> False
-   print(cfg.model_1 == model_dict)
-   >> True
+   print(cfg.model == model_dict)
+   >> True~~~~
    ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ $ pip install metadict
    print(cfg.model is model_dict)
    >> False
    print(cfg.model == model_dict)
-   >> True~~~~
+   >> True
    ```
 
 ## Documentation

--- a/metadict/__about__.py
+++ b/metadict/__about__.py
@@ -1,7 +1,7 @@
 import time
 
 _this_year = time.strftime("%Y")
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 __author__ = 'Lars Hillebrand'
 __author_email__ = 'hokage555@web.de'
 __license__ = 'Apache-2.0'

--- a/tests/test_metadict.py
+++ b/tests/test_metadict.py
@@ -11,7 +11,7 @@ from metadict.metadict import complies_variable_syntax
 
 @pytest.fixture
 def config() -> Dict:
-    dropout = 0.1
+    dropout = [[0.1, 0.2]]
     special_tokens = [['<NUM>', '<YEAR>']]
     tokenizer_params = {'special_tokens': special_tokens}
     return {'epochs': 10,
@@ -117,7 +117,7 @@ def test_get_nested(config: Dict):
 
 def test_pop_nested(config: Dict):
     cfg = MetaDict(config)
-    assert cfg.tokenizer_1.pop('special_tokens') == config['tokenizer_1'].pop('special_tokens')
+    assert cfg.optimizer.pop('lr') == config['optimizer'].pop('lr')
     assert cfg == config
 
 
@@ -236,7 +236,6 @@ def test_to_dict(config: Dict):
 
 def test_references(config: Dict):
     cfg = MetaDict(config)
-    assert cfg.tokenizer_1 is cfg.tokenizer_2
     assert cfg.tokenizer_1.special_tokens is config['tokenizer_1']['special_tokens']
 
 


### PR DESCRIPTION
Using `id(obj)` as a key in a custom memory address to object dictionary leads to edge cases.
If `obj` is garbage collected `id(new_obj)` might equal `id(obj)` and the wrong obj is retrieved from the lookup dictionary.
Hence, this functionality is removed.